### PR TITLE
Fixed battery indicator parser

### DIFF
--- a/streamdeck-battery/Internal/GHubBatteryStats.cs
+++ b/streamdeck-battery/Internal/GHubBatteryStats.cs
@@ -19,6 +19,6 @@ namespace Battery.Internal
         public double Percentage { get; set; }
 
         [JsonProperty(PropertyName = "time")]
-        public DateTime Time { get; set; }
+        public string Time { get; set; }
     }
 }

--- a/streamdeck-battery/Internal/GHubReader.cs
+++ b/streamdeck-battery/Internal/GHubReader.cs
@@ -111,7 +111,7 @@ namespace Battery.Internal
                         continue;
                     }
 
-                    if (splitName[2] != "percentage")
+                    if (splitName[2] != "warning")
                     {
                         continue;
                     }


### PR DESCRIPTION
The contents of Logitech's settings.json has changed to I modified the code accordingly. I'm not 100% sure if this is correct for all cases though, but wanted to put in the PR so you guys can have a deeper look.

This set of changes makes it work for my G703 mouse and G915 keyboard.