### PR TITLE
Adds in basic support for Razer devices

### DIFF
--- a/streamdeck-battery/Actions/SynapseBatteryStatsAction.cs
+++ b/streamdeck-battery/Actions/SynapseBatteryStatsAction.cs
@@ -121,7 +121,7 @@ namespace Battery.Actions
             return Connection.SetSettingsAsync(JObject.FromObject(settings));
         }
 
-        private void StreamDeckConnection_OnPropertyInspectorDidAppear(object sender, streamdeck_client_csharp.StreamDeckEventReceivedEventArgs<streamdeck_client_csharp.Events.PropertyInspectorDidAppearEvent> e)
+        private void StreamDeckConnection_OnPropertyInspectorDidAppear(object sender, BarRaider.SdTools.Wrappers.SDEventReceivedEventArgs<BarRaider.SdTools.Communication.SDEvents.PropertyInspectorDidAppearEvent> e)
         {
             settings.Devices = SynapseReader.Instance.GetAllDevices();
             SaveSettings();

--- a/streamdeck-battery/Actions/SynapseBatteryStatsAction.cs
+++ b/streamdeck-battery/Actions/SynapseBatteryStatsAction.cs
@@ -1,0 +1,137 @@
+﻿using BarRaider.SdTools;
+using Battery.Internal;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Threading.Tasks;
+
+namespace Battery.Actions
+{
+    [PluginActionId("com.barraider.battery.synapse")]
+    internal class SynapseBatteryStatsAction : PluginBase
+    {
+        private class PluginSettings
+        {
+            public static PluginSettings CreateDefaultSettings()
+            {
+                PluginSettings instance = new PluginSettings
+                {
+                    Devices = null,
+                    Device = String.Empty,
+                    Title = string.Empty
+                };
+                return instance;
+            }
+
+            [JsonProperty(PropertyName ="devices")]
+            public List<DeviceInfo> Devices { get; set; }
+
+            [JsonProperty(PropertyName = "device")]
+            public string Device { get; set; }
+
+            [JsonProperty(PropertyName = "title")]
+            public string Title { get; set; }
+        }
+        #region Private Members
+
+        private readonly PluginSettings settings;
+
+        private const int IMAGE_BATT_LOW = 0;
+        private const int IMAGE_BATT_MID = 1;
+        private const int IMAGE_BATT_FULL = 2;
+        private readonly string[] imageFiles = { @"images\battred.png", @"images\battyellow.png", @"images\battgreen.png" };
+
+        private Image lowImage = null;
+        private Image midImage = null;
+        private Image fullImage = null;
+        #endregion Private Members
+
+        public SynapseBatteryStatsAction(SDConnection connection, InitialPayload payload) : base(connection, payload)
+        {
+            if (payload.Settings == null || payload.Settings.Count == 0)
+            {
+                this.settings = PluginSettings.CreateDefaultSettings();
+            }
+            else
+            {
+                this.settings = payload.Settings.ToObject<PluginSettings>();
+            }
+
+            Connection.StreamDeckConnection.OnPropertyInspectorDidAppear += StreamDeckConnection_OnPropertyInspectorDidAppear;
+            PrefetchImages();
+        }
+
+        public override void Dispose()
+        {
+            Connection.StreamDeckConnection.OnPropertyInspectorDidAppear -= StreamDeckConnection_OnPropertyInspectorDidAppear;
+            Logger.Instance.LogMessage(TracingLevel.INFO, $"Destructor called");
+        }
+
+        public override void KeyPressed(KeyPayload payload)
+        {
+            Logger.Instance.LogMessage(TracingLevel.INFO, "Key Pressed");
+        }
+
+        public override void KeyReleased(KeyPayload payload) { }
+
+        public async override void OnTick()
+        {
+            var stats = SynapseReader.Instance.GetBatteryStats(settings.Device);
+            if (stats == null)
+            {
+                await Connection.SetImageAsync((String)null);
+                return;
+            }
+
+            string title = $"{(int)stats.Percentage}%{(stats.ChargingState == "Charging" ? " ⚡" : "")}";
+            if (!string.IsNullOrEmpty(settings.Title))
+            {
+                title += $"\n{settings.Title.Replace(@"\n", "\n")}";
+            }
+
+            await Connection.SetTitleAsync(title);
+            if (stats.Percentage >= 75)
+            {
+                await Connection.SetImageAsync(fullImage);
+            }
+            else if (stats.Percentage >= 25)
+            {
+                await Connection.SetImageAsync(midImage);
+            }
+            else
+            {
+                await Connection.SetImageAsync(lowImage);
+            }
+        }
+
+        public override void ReceivedSettings(ReceivedSettingsPayload payload)
+        {
+            Tools.AutoPopulateSettings(settings, payload.Settings);
+            SaveSettings();
+        }
+
+        public override void ReceivedGlobalSettings(ReceivedGlobalSettingsPayload payload) { }
+
+        #region Private Methods
+
+        private Task SaveSettings()
+        {
+            return Connection.SetSettingsAsync(JObject.FromObject(settings));
+        }
+
+        private void StreamDeckConnection_OnPropertyInspectorDidAppear(object sender, streamdeck_client_csharp.StreamDeckEventReceivedEventArgs<streamdeck_client_csharp.Events.PropertyInspectorDidAppearEvent> e)
+        {
+            settings.Devices = SynapseReader.Instance.GetAllDevices();
+            SaveSettings();
+        }
+        private void PrefetchImages()
+        {
+            lowImage = Image.FromFile(imageFiles[IMAGE_BATT_LOW]);
+            midImage = Image.FromFile(imageFiles[IMAGE_BATT_MID]);
+            fullImage = Image.FromFile(imageFiles[IMAGE_BATT_FULL]);
+        }
+        #endregion
+    }
+}

--- a/streamdeck-battery/Battery.csproj
+++ b/streamdeck-battery/Battery.csproj
@@ -65,11 +65,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Actions\ICueBatteryStatsAction.cs" />
+    <Compile Include="Actions\SynapseBatteryStatsAction.cs" />
     <Compile Include="Actions\XboxControllerBatteryStatsAction.cs" />
     <Compile Include="Actions\LogitechBatteryStatsAction.cs" />
     <Compile Include="Internal\ExtensionMethods.cs" />
     <Compile Include="Internal\GHubBatteryStats.cs" />
     <Compile Include="Internal\DeviceInfo.cs" />
+    <Compile Include="Internal\SynapseBatteryStats.cs" />
+    <Compile Include="Internal\SynapseBatteryReader.cs" />
     <Compile Include="Internal\ICueBatteryStats.cs" />
     <Compile Include="Internal\ICueReader.cs" />
     <Compile Include="Internal\GHubReader.cs" />
@@ -116,6 +119,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Images\pluginIcon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PropertyInspector\SynapseBattery.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="PropertyInspector\XboxBattery.html">

--- a/streamdeck-battery/Internal/SynapseBatteryReader.cs
+++ b/streamdeck-battery/Internal/SynapseBatteryReader.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace Battery.Internal
+{
+    internal class SynapseReader
+    {
+        #region Private members
+
+        private static SynapseReader instance = null;
+        private static readonly object objLock = new object();
+       
+        private List<SynapseBatteryStats> devices = new List<SynapseBatteryStats>();
+
+        #endregion
+
+        #region Constructors
+
+        public static SynapseReader Instance
+        {
+            get
+            {                
+                if (instance != null)
+                {
+                    return instance;
+                }
+
+                lock (objLock)
+                {
+                    if (instance == null)
+                    {
+                        instance = new SynapseReader();
+                    }
+                    return instance;
+                }
+            }
+        }
+
+        private SynapseReader()
+        {
+            var ts = new ThreadStart(ReadLogFiles);
+            var backgroundThread = new Thread(ts);
+            backgroundThread.Start();
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public List<DeviceInfo> GetAllDevices()
+        {
+            // TODO: Need to find a way of forcing a comms check with devices, as they are not populated in the log until one plugs/unplugs them
+            return devices.Select(s => new DeviceInfo() { Name = s.DeviceName }).ToList();
+        }
+
+        public SynapseBatteryStats GetBatteryStats(string deviceName)
+        {
+            if (devices == null || !devices.Any(x=>x.DeviceName == deviceName))
+            {
+                return null;
+            }
+
+            return devices.Single(x=>x.DeviceName == deviceName);
+        }
+
+
+        #endregion
+
+        #region Private Methods
+
+        private void ReadLogFiles()
+        {
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var fileName = $"{userProfile}\\AppData\\Local\\Razer\\Synapse3\\Log\\Razer Synapse 3.log";
+            using (StreamReader reader = new StreamReader(new FileStream(fileName,
+                                 FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            {
+                //start at the end of the file
+                long lastMaxOffset = reader.BaseStream.Length;
+
+                while (true)
+                {
+                    System.Threading.Thread.Sleep(250);
+
+
+                    //if the file size has not changed, idle
+                    if (reader.BaseStream.Length == lastMaxOffset)
+                        continue;
+
+                    //seek to the last max offset
+                    reader.BaseStream.Seek(lastMaxOffset, SeekOrigin.Begin);
+
+                    //read out of the file until the EOF
+                    string line = "";
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        // The log file should contain entries like:
+                        //   2023 - 03 - 20 18:34:38.4929 INFO 1 Battery Get By Device Handle:
+                        //   Name: Razer BlackWidow
+                        //   Product_ID: 602(0x25A)
+                        //   Edition_ID: 0(0x0)
+                        //   Vendor_ID: 5426(0x1532)
+                        //   Layout: 6(0x6)
+                        //   Serial_Number: IO2204F46400041
+                        //   Firmware_Version: 
+                        //   Handle: 481147576(0x1CADBAB8)
+                        //   Type: 2
+                        //   SKU_ID: SKU
+                        //   RegionId: 0
+                        //   Feature Name: Battery
+                        //   Feature Id: 1315d015 - e350 - 4541 - 9658 - a6030fb62776
+                        //   Battery Percentage: 95
+                        //   Battery State: Charging
+                        //   Device on Dock State: Invalid
+                        //   Charging StatusInvalid
+                        if (line.Contains("INFO 1 Battery Get By Device Handle"))
+                        {
+                            var dt = DateTime.Parse(line.Substring(0, 24));
+
+
+                            var deviceName = reader.ReadLine();
+                            deviceName = deviceName?.Substring(deviceName.LastIndexOf(':') + 2);
+
+
+                            var device = devices.SingleOrDefault(x => x.DeviceName == deviceName);
+
+                            if (device == null)
+                            {
+                                device = new SynapseBatteryStats { DeviceName = deviceName };
+                                devices.Add(device);
+                            }
+
+                            device.UpdateDate = dt;
+
+                            var gotEverything = false;
+                            while (gotEverything == false)
+                            {
+                                line = reader.ReadLine();
+                                if (line.Contains("Battery Percentage:"))
+                                {
+                                    device.Percentage = Convert.ToInt32(line.Substring(line.LastIndexOf(':') + 2));
+                                }
+
+                                if (line.Contains("Battery State:"))
+                                {
+                                    device.ChargingState = line.Substring(line.LastIndexOf(':') + 2);
+                                    gotEverything = true;
+                                }
+                            }
+                        }
+                    }
+
+                    //update the last max offset
+                    lastMaxOffset = reader.BaseStream.Position;
+                }
+            }
+        }
+
+
+        #endregion
+    }
+}

--- a/streamdeck-battery/Internal/SynapseBatteryReader.cs
+++ b/streamdeck-battery/Internal/SynapseBatteryReader.cs
@@ -75,16 +75,14 @@ namespace Battery.Internal
         {
             var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             var fileName = $"{userProfile}\\AppData\\Local\\Razer\\Synapse3\\Log\\Razer Synapse 3.log";
-            using (StreamReader reader = new StreamReader(new FileStream(fileName,
-                                 FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            using (StreamReader reader = new StreamReader(new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
             {
                 //start at the end of the file
                 long lastMaxOffset = reader.BaseStream.Length;
 
                 while (true)
                 {
-                    System.Threading.Thread.Sleep(250);
-
+                    Thread.Sleep(1000);
 
                     //if the file size has not changed, idle
                     if (reader.BaseStream.Length == lastMaxOffset)
@@ -120,19 +118,20 @@ namespace Battery.Internal
                         {
                             var dt = DateTime.Parse(line.Substring(0, 24));
 
-
                             var deviceName = reader.ReadLine();
                             deviceName = deviceName?.Substring(deviceName.LastIndexOf(':') + 2);
 
-
+                            // Have we already seen this device?
                             var device = devices.SingleOrDefault(x => x.DeviceName == deviceName);
 
                             if (device == null)
                             {
+                                // We have not, lets add it to the list of devices
                                 device = new SynapseBatteryStats { DeviceName = deviceName };
                                 devices.Add(device);
                             }
 
+                            // Update the device properties
                             device.UpdateDate = dt;
 
                             var gotEverything = false;
@@ -158,7 +157,6 @@ namespace Battery.Internal
                 }
             }
         }
-
 
         #endregion
     }

--- a/streamdeck-battery/Internal/SynapseBatteryStats.cs
+++ b/streamdeck-battery/Internal/SynapseBatteryStats.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Battery.Internal
+{
+    internal class SynapseBatteryStats
+    {
+        [JsonProperty(PropertyName = "updatedate")]
+        public DateTime UpdateDate { get; set; }
+
+        [JsonProperty(PropertyName = "devicename")]
+        public string DeviceName { get; set; }
+
+        [JsonProperty(PropertyName = "chargingstate")]
+        public string ChargingState { get; set; }
+
+        [JsonProperty(PropertyName = "percentage")]
+        public int Percentage { get; set; }
+    }
+}

--- a/streamdeck-battery/PropertyInspector/SynapseBattery.html
+++ b/streamdeck-battery/PropertyInspector/SynapseBattery.html
@@ -1,0 +1,28 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name=viewport content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,minimal-ui,viewport-fit=cover">
+    <meta name=apple-mobile-web-app-capable content=yes>
+    <meta name=apple-mobile-web-app-status-bar-style content=black>
+    <title>GHub Battery Settings</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi@latest/src/sdpi.css">
+    <script src="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi@latest/src/sdtools.common.js"></script>
+    <script src="GHubBattery.js"></script>
+</head>
+<body>
+    <div class="sdpi-wrapper">
+        <details class="message">
+            <summary>For support/feedback/suggestions contact me at <span class="linkspan" onclick="openWebsite()">https://BarRaider.com</span> </summary>
+        </details>
+        <div class="sdpi-item" id="dvDevices">
+            <div class="sdpi-item-label">Device</div>
+            <select class="sdpi-item-value select sdProperty sdList" id="devices" oninput="setSettings()" sdListTextProperty="name" sdListValueProperty="name" sdValueField="device"></select>
+        </div>
+        <div class="sdpi-item" id="dvTitle">
+            <div class="sdpi-item-label">Title</div>
+            <input class="sdpi-item-value sdProperty" placeholder="" value="" id="title" oninput="setSettings()">
+        </div>
+    </div>
+</body>
+</html>

--- a/streamdeck-battery/PropertyInspector/SynapseBattery.html
+++ b/streamdeck-battery/PropertyInspector/SynapseBattery.html
@@ -5,12 +5,14 @@
     <meta name=viewport content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,minimal-ui,viewport-fit=cover">
     <meta name=apple-mobile-web-app-capable content=yes>
     <meta name=apple-mobile-web-app-status-bar-style content=black>
-    <title>GHub Battery Settings</title>
+    <title>Razer Synapse Battery Settings</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi@latest/src/sdpi.css">
     <script src="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi@latest/src/sdtools.common.js"></script>
-    <script src="GHubBattery.js"></script>
 </head>
 <body>
+    <details class="message">
+        <summary>If there are no devices in the dropdown below, disconnect and reconnect the device to refresh the list. Log files are parsed once every second</summary>
+    </details>
     <div class="sdpi-wrapper">
         <details class="message">
             <summary>For support/feedback/suggestions contact me at <span class="linkspan" onclick="openWebsite()">https://BarRaider.com</span> </summary>
@@ -20,7 +22,7 @@
             <select class="sdpi-item-value select sdProperty sdList" id="devices" oninput="setSettings()" sdListTextProperty="name" sdListValueProperty="name" sdValueField="device"></select>
         </div>
         <div class="sdpi-item" id="dvTitle">
-            <div class="sdpi-item-label">Title</div>
+            <div class="sdpi-item-label">Subtitle</div>
             <input class="sdpi-item-value sdProperty" placeholder="" value="" id="title" oninput="setSettings()">
         </div>
     </div>

--- a/streamdeck-battery/manifest.json
+++ b/streamdeck-battery/manifest.json
@@ -53,10 +53,28 @@
       "Tooltip": "Show battery status of a connected Xbox controller live on the Stream Deck",
       "UUID": "com.barraider.battery.xbox",
       "PropertyInspectorPath": "PropertyInspector/XboxBattery.html"
+    },
+    {
+      "Icon": "Images/icon",
+      "Name": "Razer Device Battery",
+      "States": [
+        {
+          "Image": "Images/pluginAction",
+          "TitleAlignment": "middle",
+          "FontSize": "10",
+          "TitleColor": "Yellow"
+
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "DisableCaching": true,
+      "Tooltip": "Shows Synapse battery stats live on the Stream Deck",
+      "UUID": "com.barraider.battery.synapse",
+      "PropertyInspectorPath": "PropertyInspector/SynapseBattery.html"
     }
   ],
   "Author": "BarRaider",
-  "Description": "Battery levels for Logitech G HUB, CORSAIR iCue, XBox on the Stream Deck",
+  "Description": "Battery levels for Logitech G HUB, CORSAIR iCue, XBox, Razer Synapse on the Stream Deck",
   "Name": "Battery",
   "Icon": "Images/pluginIcon",
   "URL": "https://BarRaider.com/",


### PR DESCRIPTION
Been meaning to get to this for a while, this PR adds in support for parsing the Razer Synapse log file in order to get device battery details.

If the device you want the stats on does not show up in the Device drop down, power cycle it to force an entry to be written to the log (I have not been able to find a way to do this programmatically)

Includes charging status when you plug/unplug the device

![image](https://user-images.githubusercontent.com/1998970/228012005-9fb0162b-87d8-4cb9-a41c-65398b866dcf.png)
