### PR TITLE
Further tweaks to Razer Synapse battery monitor

### DIFF
--- a/streamdeck-battery/Internal/SynapseBatteryReader.cs
+++ b/streamdeck-battery/Internal/SynapseBatteryReader.cs
@@ -21,6 +21,8 @@ namespace Battery.Internal
         private readonly string SYNAPSE_FULL_PATH;
         private const int REFRESH_TIMEOUT_MS = 10000;
         private readonly Timer tmrRefreshStats;
+        
+        private long lastMaxOffset = 0;
 
         #endregion
 
@@ -106,12 +108,9 @@ namespace Battery.Internal
             {
                 using (StreamReader reader = new StreamReader(new FileStream(SYNAPSE_FULL_PATH, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
                 {
-                    //start at the end of the file
-                    long lastMaxOffset = reader.BaseStream.Length;
-
-                    //if the file size has not changed, idle
                     if (reader.BaseStream.Length == lastMaxOffset)
                     {
+                        // Filesize has not changed since previous check, idle.
                         return;
                     }
 


### PR DESCRIPTION
Make `lastMaxOffset` global so that we can keep track of where we got to between timer calls.

On first run, read in complete file rather than starting at the end, which has the advantage of any existing files the log knows about appearing on startup (within a couple of seconds) without needing to connect/disconnect the device.

