### PR TITLE
Fix edge-case where "background-manager-frame.log" exists in the Razer log directory

### DIFF
--- a/streamdeck-battery/Battery.csproj
+++ b/streamdeck-battery/Battery.csproj
@@ -92,7 +92,6 @@
     <Compile Include="Internal\ICueReader.cs" />
     <Compile Include="Internal\GHubReader.cs" />
     <Compile Include="Internal\ToolbarScanner.cs" />
-    <Compile Include="Internal\UpdateHandler.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
As discussed in DMs, I have identified an issue in _some_ cases where an additional file that matches the `background-manager*.log` exists on the user's system. What's odd is that this file never existed on my own machine, and still does not!

Confirmed working by two users that reported the issue to me.

I'm not married to the additional logging, so can remove it upon request, but figured it would make it easier to debug in case of any future changes to the Razer engine.

Lastly, I've removed the include for UpdateHandler.cs in the csproj file as the application will not compile with that line there.